### PR TITLE
Initial public draft of CoC doc

### DIFF
--- a/codeofconduct.md
+++ b/codeofconduct.md
@@ -1,0 +1,55 @@
+# Values
+
+NRE Labs has always been open source and we expect it always will be.
+
+As an education-focused project, we believe above all in mentoring and helping to create the network reliability engineering leaders and network-savvy open source leaders and contributors of the future.
+
+We believe that diversity in contributors’ ideas and experiences improves the relevance of the project platform and lessons. This means ensuring that discussions about the project must be  respectful and constructive at all times, and that we actively welcome contributors of all backgrounds, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We have selected English as the default language of Project operations due to its extensive worldwide adoption by both primary and secondary speakers. All participants are expected to be respectful and encouraging of regional variations and accents. Internationalization of Project artifacts is very welcome.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others’ private information, such as a physical or electronic address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project committers, which includes non-technical leaders such as the Steering Committee chair, are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project committers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+This Code of Conduct also applies outside the project spaces when the Project Steering Committee has a reasonable belief that an individual’s behavior may have a negative impact on the project or its community.
+
+## Conflict Resolution
+
+We do not believe that all conflict is bad; healthy debate and disagreement often yield positive results. However, it is never okay to be disrespectful or to engage in behavior that violates the project’s code of conduct.
+
+If you see someone violating the code of conduct, you are encouraged to address the behavior directly with those involved. Many issues can be resolved quickly and easily, and this gives people more control over the outcome of their dispute. If you are unable to resolve the matter for any reason, or if the behavior is threatening or harassing, report it. We are dedicated to providing an environment where participants feel welcome and safe.
+
+Reports should be directed to [CoC@NRELabs.com](mailto:CoC@NRELabs.com) for NRE Labs, which will include the Steering Committee. If for any reason you are uncomfortable reaching out the broader CoC group, please email the Steering Committee Director.
+
+We will investigate every complaint, but you may not receive a direct response. We will use our discretion in determining when and how to follow up on reported incidents, which may range from not taking action to permanent expulsion from the project and project-sponsored spaces. We will notify the accused of the report and provide them an opportunity to discuss it before any action is taken. The identity of the reporter will be omitted from the details of the report supplied to the accused. In potentially harmful situations, such as ongoing harassment or threats to anyone’s safety, we may take action without notice.
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 1.4, available at [https://www.contributor-covenant.org/version/1/4/code-of-conduct.html](https://www.contributor-covenant.org/version/1/4/code-of-conduct.html)
+
+

--- a/codeofconduct.md
+++ b/codeofconduct.md
@@ -44,12 +44,11 @@ We do not believe that all conflict is bad; healthy debate and disagreement ofte
 
 If you see someone violating the code of conduct, you are encouraged to address the behavior directly with those involved. Many issues can be resolved quickly and easily, and this gives people more control over the outcome of their dispute. If you are unable to resolve the matter for any reason, or if the behavior is threatening or harassing, report it. We are dedicated to providing an environment where participants feel welcome and safe.
 
-Reports should be directed to [CoC@NRELabs.com](mailto:CoC@NRELabs.com) for NRE Labs, which will include the Steering Committee. If for any reason you are uncomfortable reaching out the broader CoC group, please email the Steering Committee Director.
+Reports should be directed to [nrelabs@gmail.com](mailto:nrelabs@gmail.com) for NRE Labs, which will include the Steering Committee. If for any reason you are uncomfortable reaching out the broader CoC group, please email the Steering Committee Director.
 
 We will investigate every complaint, but you may not receive a direct response. We will use our discretion in determining when and how to follow up on reported incidents, which may range from not taking action to permanent expulsion from the project and project-sponsored spaces. We will notify the accused of the report and provide them an opportunity to discuss it before any action is taken. The identity of the reporter will be omitted from the details of the report supplied to the accused. In potentially harmful situations, such as ongoing harassment or threats to anyone’s safety, we may take action without notice.
 
 ## Attribution
 
 This Code of Conduct is adapted from the Contributor Covenant, version 1.4, available at [https://www.contributor-covenant.org/version/1/4/code-of-conduct.html](https://www.contributor-covenant.org/version/1/4/code-of-conduct.html)
-
 


### PR DESCRIPTION
This is the initial draft for the NRE Labs Code of Conduct document. Please use the "files changed" tab to inspect the contents and provide in-line comments where relevant.

The credit for this draft goes to @LCaywood - she asked that I post this via PR on her behalf.