### PR TITLE
Blueprint for Scratch-volume and Code Editor Feature

### DIFF
--- a/blueprints/blueprint-scratch-editor.md
+++ b/blueprints/blueprint-scratch-editor.md
@@ -1,0 +1,7 @@
+# LiveLesson-wide Shared Directory and Web Editor
+
+- Create a single shared scratch directory
+- Lesson authors can pre-populate scratch directory by placing files in a `scratch` directory within
+  the lesson dir in Github - Antidote will copy these into the live scratch dir. This replaces the existing model where Antidote-y files are mixed with lesson examples and scripts.
+- Optional support for an editor tab that has R/W access to this directory (boolean var in the lesson meta)
+


### PR DESCRIPTION
Following on from a conversation @cloudtoad  and I had about introducing a scratch space and code editor feature into the platform. This is a feature that warrants its own discussion - and can be done any time, before or after Syringe MP1, but should probably wait until after MP2 is finished.